### PR TITLE
Fix md5 class import

### DIFF
--- a/adafruit_hashlib/_md5.py
+++ b/adafruit_hashlib/_md5.py
@@ -27,7 +27,7 @@ MD5 Hash Algorithm.
 * Author(s): Brent Rubell
 """
 # pylint: disable=too-few-public-methods
-class MD5():
+class md5():
     """RSA MD5 Algorithm class."""
     def __init__(self, s=None):
         raise NotImplementedError("MD5 digests not currently implemented in this module.")

--- a/adafruit_hashlib/_md5.py
+++ b/adafruit_hashlib/_md5.py
@@ -26,7 +26,7 @@
 MD5 Hash Algorithm.
 * Author(s): Brent Rubell
 """
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods, invalid-name
 class md5():
     """RSA MD5 Algorithm class."""
     def __init__(self, s=None):


### PR DESCRIPTION
Class `MD5` is expected by `__init__.py` to be l-case `md5`. 