### PR TITLE
Update sha1 constructor

### DIFF
--- a/adafruit_hashlib/_sha1.py
+++ b/adafruit_hashlib/_sha1.py
@@ -128,9 +128,10 @@ class sha1():
     digest_size = SHA_DIGESTSIZE
     block_size = SHA_BLOCKSIZE
     name = "sha1"
-    def __init__(self):
+    def __init__(self, data=None):
         """Construct a SHA-1 hash object.
-        :param bytes data: data to process
+        :param bytes data: Optional data to process
+
         """
         # Initial Digest Variables
         self._h = (0x67452301,
@@ -145,6 +146,9 @@ class sha1():
 
         # Length in bytes of all data that has been processed so far
         self._msg_byte_len = 0
+
+        if data:
+            self.update(data)
 
     def _create_digest(self):
         """Returns finalized digest variables for the data processed so far.


### PR DESCRIPTION
SHA1 constructor now accepts optional `data` kwarg to reflect CPython's `hashlib` api:  `hashlib.sha1(name[, data])`. This constructor now reflects the other sha module constructors within this library. 

Output from `Adafruit CircuitPython 5.0.0-beta.2 on 2019-12-20; Adafruit PyPortal with samd51j20`

```
>>> hashlib.sha1(b"data!")
<sha1 object at 2002c2d0>
>>> hashlib.sha1(b"data!").hexdigest()
'cd3618849b8025aa2d5da3f33d7311d31f66e677'
```