### PR TITLE
Added reference to attributes from parent module in CPython

### DIFF
--- a/adafruit_hashlib/__init__.py
+++ b/adafruit_hashlib/__init__.py
@@ -23,14 +23,8 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 """
 try:
-    import hashlib
-    # pylint: disable=invalid-name
-    md5 = hashlib.md5
-    sha1 = hashlib.sha1
-    sha224 = hashlib.sha224
-    sha256 = hashlib.sha256
-    sha384 = hashlib.sha384
-    sha512 = hashlib.sha512
+    from hashlib import md5, sha1, sha224, sha256, sha512
+    from hashlib import sha3_384 as sha384
 except ImportError:
     from adafruit_hashlib._sha256 import sha224, sha256
     from adafruit_hashlib._sha512 import sha384, sha512

--- a/adafruit_hashlib/__init__.py
+++ b/adafruit_hashlib/__init__.py
@@ -24,6 +24,7 @@ Implementation Notes
 """
 try:
     import hashlib
+    # pylint: disable=invalid-name
     md5 = hashlib.md5
     sha1 = hashlib.sha1
     sha224 = hashlib.sha224

--- a/adafruit_hashlib/__init__.py
+++ b/adafruit_hashlib/__init__.py
@@ -24,6 +24,12 @@ Implementation Notes
 """
 try:
     import hashlib
+    md5 = hashlib.md5
+    sha1 = hashlib.sha1
+    sha224 = hashlib.sha224
+    sha256 = hashlib.sha256
+    sha384 = hashlib.sha384
+    sha512 = hashlib.sha512
 except ImportError:
     from adafruit_hashlib._sha256 import sha224, sha256
     from adafruit_hashlib._sha512 import sha384, sha512


### PR DESCRIPTION
This just a simple patch to add references to the implementation's hashlib attributes if it exists.

This omission caused the "*adafruit_rsa*" library to return the following error on CPython, but not on CircuitPython:
```
<redacted>
File "<redacted>\adafruit_rsa\__init__.py", line 17, in <module>
    from adafruit_rsa.pkcs1 import (
File "<redacted>\adafruit_rsa\pkcs1.py", line 37, in <module>
    "MD5": hashlib.md5,
AttributeError: module 'adafruit_hashlib' has no attribute 'md5'
```

More checks can be added if needed in order to reference the library's implementation of the hashing algorithms if they are not present in the implementation's version of *hashlib*.