### PR TITLE
Add missing new line in docstring for hashlib.new

### DIFF
--- a/adafruit_hashlib/__init__.py
+++ b/adafruit_hashlib/__init__.py
@@ -40,6 +40,7 @@ ALGOS_AVAIL = ["sha1", "md5", "sha224", "sha256", "sha384", "sha512"]
 
 def new(algo, data=b""):
     """Creates a new hashlib object.
+
     :param str algo: Name of the desired algorithm.
     :param str data: First parameter.
     """


### PR DESCRIPTION
The missing line between the method description and the list of parameters leads to broken formatting in the docs. It needs to be present for the list of parameters to be correctly formatted.

Screenshot from [this page](https://docs.circuitpython.org/projects/hashlib/en/latest/api.html), highlighted:

<img width="699" alt="image" src="https://user-images.githubusercontent.com/7276/178859362-2f1d6356-f081-46f6-bc85-31500ba58074.png">
