### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_hashlib/_sha256.py
+++ b/adafruit_hashlib/_sha256.py
@@ -9,7 +9,7 @@
 SHA-256 Hash Algorithm.
 * Author(s): Tom St Denis, Paul Sokolovsky, Brent Rubell
 """
-# pylint: disable=invalid-name, unnecessary-lambda, missing-docstring
+# pylint: disable=invalid-name, unnecessary-lambda, unnecessary-lambda-assignment, missing-docstring
 
 # SHA Block size and message digest sizes, in bytes.
 SHA_BLOCKSIZE = 64

--- a/adafruit_hashlib/_sha512.py
+++ b/adafruit_hashlib/_sha512.py
@@ -10,7 +10,7 @@ SHA-512 Hash Algorithm, this code was ported from
 CPython's sha512module.c.
 * Author(s): Paul Sokolovsky, Brent Rubell
 """
-# pylint: disable=invalid-name, unnecessary-lambda, missing-docstring, line-too-long
+# pylint: disable=invalid-name, unnecessary-lambda, unnecessary-lambda-assignment, missing-docstring, line-too-long
 
 # SHA Block size and message digest sizes, in bytes.
 SHA_BLOCKSIZE = 128


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
 ************* Module adafruit_hashlib._sha512
Error: adafruit_hashlib/_sha512.py:34:4: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha512.py:37:5: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha512.py:38:6: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha512.py:39:4: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha512.py:40:4: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha512.py:41:9: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha512.py:42:9: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha512.py:43:9: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha512.py:44:9: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
************* Module adafruit_hashlib._sha256
Error: adafruit_hashlib/_sha256.py:33:4: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha256.py:35:5: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha256.py:36:6: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha256.py:37:4: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha256.py:38:4: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha256.py:39:9: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha256.py:40:9: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha256.py:41:9: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: adafruit_hashlib/_sha256.py:42:9: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
```
